### PR TITLE
Fix syntax error with empty-sequence()

### DIFF
--- a/modules/userManager.xqm
+++ b/modules/userManager.xqm
@@ -66,7 +66,7 @@ declare function usermanager:list-users($pattern as xs:string) as element(json:v
     </json:value>
 };
 
-declare function usermanager:delete-user($user) as empty() {
+declare function usermanager:delete-user($user) as empty-sequence() {
     
     (: TODO implement secman module functions instead :)
     xmldb:delete-user($user)

--- a/modules/userManager.xqm
+++ b/modules/userManager.xqm
@@ -200,7 +200,7 @@ declare function usermanager:group-exists($group) as xs:boolean {
     secman:list-groups() = $group
 };
 
-declare function usermanager:delete-group($group) as empty() {
+declare function usermanager:delete-group($group) as empty-sequence() {
     secman:delete-group($group)
 };
 


### PR DESCRIPTION
fixes an error for 3.7.0-SNAPSHOT and beyond

```
Caused by: org.exist.xquery.XPathException: err:XPST0003 error found while loading module usermanager: Error while loading module modules/userManager.xqm: Syntax error within user defined function usermanager:delete-user: unexpected token: ( [at line 69, column 57]
	at org.exist.xquery.parser.XQueryParser.functionDecl(XQueryParser.java:2561)
	at org.exist.xquery.parser.XQueryParser.functionDeclUp(XQueryParser.java:1695)
	at org.exist.xquery.parser.XQueryParser.prolog(XQueryParser.java:960)
	at org.exist.xquery.parser.XQueryParser.libraryModule(XQueryParser.java:667)
	at org.exist.xquery.parser.XQueryParser.module(XQueryParser.java:588)
	at org.exist.xquery.parser.XQueryParser.xpath(XQueryParser.java:499)
	at org.exist.xquery.XQueryContext.compileModule(XQueryContext.java:2903)
	at org.exist.xquery.XQueryContext.compileOrBorrowModule(XQueryContext.java:2845)
	at org.exist.xquery.XQueryContext.importModule(XQueryContext.java:2756)
	at org.exist.xquery.parser.XQueryTreeParser.importDecl(XQueryTreeParser.java:6312)
	at org.exist.xquery.parser.XQueryTreeParser.prolog(XQueryTreeParser.java:5340)
	at org.exist.xquery.parser.XQueryTreeParser.mainModule(XQueryTreeParser.java:4042)
	at org.exist.xquery.parser.XQueryTreeParser.module(XQueryTreeParser.java:3987)
	at org.exist.xquery.parser.XQueryTreeParser.xpath(XQueryTreeParser.java:3642)
	at org.exist.xquery.XQuery.compile(XQuery.java:128)
	at org.exist.xquery.XQuery.compile(XQuery.java:79)
	at org.exist.xquery.XQuery.compile(XQuery.java:71)
	at org.exist.http.urlrewrite.XQueryURLRewrite.runQuery(XQueryURLRewrite.java:687)
	at org.exist.http.urlrewrite.XQueryURLRewrite.service(XQueryURLRewrite.java:256)
	... 36 more
```