### PR TITLE
Remove deprecated xmldb function calls, fix save & delete user operations

### DIFF
--- a/existdb-usermanager.html
+++ b/existdb-usermanager.html
@@ -875,8 +875,7 @@
             _handleDeleteUser(e) {
                 console.log("_handleDeleteUser ", this.selectedUser.user);
                 if (confirm('Really delete this user?')) {
-                    this.$.deleteUser.url = this.rootPath + this.userUrl + this.selectedUser.user;
-                    this.$.deleteUser.url = this.importPath + 'api/user/';
+                    this.$.deleteUser.url = this.importPath + this.userUrl + this.selectedUser.user;
                     this.$.deleteUser.generateRequest();
                 }
             }
@@ -1127,4 +1126,3 @@
         window.customElements.define(ExistdbUsermanager.is, ExistdbUsermanager);
     </script>
 </dom-module>
-

--- a/modules/login-helper.xql
+++ b/modules/login-helper.xql
@@ -32,11 +32,11 @@ declare %private function login-helper:fallback-login($domain as xs:string, $max
             error(xs:QName("login"), "Persistent login module not enabled in this version of eXist-db")
         else if ($logout) then
             session:invalidate()
-        else 
+        else
             if ($user) then
                 let $isLoggedIn := xmldb:login("/db", $user, $password, true())
                 return
-                    if ($isLoggedIn and (not($asDba) or xmldb:is-admin-user($user))) then (
+                    if ($isLoggedIn and (not($asDba) or sm:is-dba($user))) then (
                         session:set-attribute("eXide.user", $user),
                         session:set-attribute("eXide.password", $password),
                         request:set-attribute($domain || ".user", $user),

--- a/modules/userManager.xqm
+++ b/modules/userManager.xqm
@@ -169,7 +169,7 @@ declare function usermanager:update-user($user-name as xs:string, $user-json as 
                 (: if a password is provided, we always change the password, as we dont know what the original password was :)
                 for $group in secman:get-user-groups($user) return secman:remove-group-member($group, $user),
                 for $group in $groups return if(secman:group-exists($group)) then secman:add-group-member($group, $user) else (),
-                secman:passwd($user, $password),
+                if($password) then secman:passwd($user, $password) else (),
 
                 (: success :)
                 true()

--- a/modules/userManager.xqm
+++ b/modules/userManager.xqm
@@ -198,7 +198,7 @@ declare function usermanager:group-exists($group) as xs:boolean {
 };
 
 declare function usermanager:delete-group($group) as empty-sequence() {
-    secman:delete-group($group)
+    secman:remove-group($group)
 };
 
 declare function usermanager:create-group($group-json as element(json)) as xs:string? {


### PR DESCRIPTION
**Please review & merge ASAP**: The deprecated xmldb function calls have been deleted in eXist's develop branch, and are needed for compatibility with the forthcoming release of eXist 5.0.0-RC8.

Closes #17.